### PR TITLE
Updates travis to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: false
 
 language: cpp


### PR DESCRIPTION
One of the tests of internal `any_t` fails to compile on gcc 4.8, but as far as I can tell, everything else works fine. This is worth investigating but not reverting.